### PR TITLE
Update Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v2
-      - uses: CupOfTea696/gh-action-auto-release@v1.0.0
+      - uses: crazy-max/ghaction-github-pages@v3.1.0
         with:
-          title: "Release: $version"
-          tag: "v$semver"
-          draft: false
-          regex: "/^Release: #{semver}$/i"
+          allow_empty_commit: false
+          jekyll: false
+          verbose: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
change "CupOfTea696/gh-action-auto-release@v1.0.0" to "crazy-max/ghaction-github-pages@v3.1.0"
I find out the crazy-max GitHub action for GitHub pages is more beneficial.

Check out https://github.com/crazy-max/ghaction-github-pages for more details.