### PR TITLE
بهبود دستور زبان و اشکالات متن

### DIFF
--- a/content/chapter 1/1.10-map.md
+++ b/content/chapter 1/1.10-map.md
@@ -6,7 +6,7 @@ weight: 1010
 
 ## 1.10.1 مقدمه
 - {{< tooltip text="نقشه" note="map" >}}، یک نوع ساختار داده است.
-- {{< tooltip text="نقشه" note="map" >}}(ها) جهت جمع‌آوری و نگهداری مجموعه‌ای از داده‌ها استفاده می‌گردند.
+- {{< tooltip text="نقشه" note="map" >}}ها جهت جمع‌آوری و نگهداری مجموعه‌ای از داده‌ها استفاده می‌گردند.
 - {{< tooltip text="نقشه" note="map" >}}، از نوع داده‌های {{< tooltip text="انجمنی" note="associative data type" >}} (هش) بصورت {{< tooltip text="«کلید-مقدار»" note="key-value" >}} است.
 - {{< tooltip text="نقشه" note="map" >}}، مجموعه‌ای از داده‌ها بصورت  {{< tooltip text="جفت‌‌های مرتب‌نشده" note="unordered key:value pairs" >}} است.
 ## 1.10.2 تعریف
@@ -16,7 +16,6 @@ map[KeyType]ValueType
 ````
  کلمه کلیدی `map` و بعد نوع کلید و در آخر هم نوع مقدار تعریف می‌شود.
  - کلید: برای اشاره به یک مقدار ذخیره شده، نیاز به یک نام‌ داریم و این یعنی «کلید» آن مقدار.
-	- مقدار کلید در یک مپ، باید {{< tooltip text="یکتا" note="unique" >}} باشد.
 	- محدودیت: برای تعریف کلید، از انواع تایپ‌هایی که {{< tooltip text="قابل مقایسه" note="comparable " >}} هستند، می‌توان استفاده کرد:
 		- Boolean(s)
 		- Number(s)
@@ -125,7 +124,7 @@ func main() {
 ## 1.10.6 عملیات CRUD روی مپ
 {{< tabs "myid" >}}
 {{< tab "C : Create" >}}
-برای ایجاد مپ، در قسمت [[#ایجاد و مقداردهی اولیه:]] توضیح داده شده است.
+برای ایجاد مپ، اغلب از تابع make استفاده می شود:
 ```go
 package main  
   
@@ -230,38 +229,38 @@ func delete(m map[Type]Type1, key Type)
 
 ## 1.10.7 بررسی وجود کلید
 
-یکی از خدماتی که مپ ارائه می‌دهد،‌ پاسخ به سوال وجود یک کلید خاص در مپ می‌باشد که به‌عنوان راهکاری برای حل مسائل از آن استفاده می‌شود. مثال زیر را ببینید:
+به کد زیر توجه کنید:
 ```go
-package main
-
-import "fmt"
-
-func main() {
-
-	var personData = map[string]string{"name": "frank", "family": "colleti", "dob": "1970-05-12"}
-
-	name, nameExist := personData["name"]
-	family, familyExist := personData["family"]
-	dob, dobExist := personData["dob"]
-	organization, organizationExist := personData["organization"]
-
-	fmt.Println(name, nameExist)	
-			//frank true
-	fmt.Println(family, familyExist)
-			//colleti true
-	fmt.Println(dob, dobExist)
-			//1970-05-12 true
-	fmt.Println(organization, organizationExist)
-			// false
+package main  
+  
+import "fmt"  
+  
+func main() {  
+    x := make(map[string]int)  
+    a := x["num"]  
+    fmt.Println(a) // 0  
+  
+    x["num"] = 0  
+    b := x["num"]  
+    fmt.Println(b) // 0  
 }
-
-
 ```
-
-- این روش بیشتر به اسم `comma, ok` شناخته می‌شود و بسیاری از توابع چه در کتابخانه استاندارد و چه کتابخانه‌های عمومی در گولنگ، از این نوع نام‌گذاری برای برگشت دادن مقدار و ارور پشتیبانی می‌کنند. 
-- در مثال بالا تمامی متغیرهایی که با `Exist` تمام می‌شوند برای برسی وجود و عدم وجود یک کلید در `مپ` استفاده می‌شوند، به این صورت که اگر مقدار مشخص شده در `مپ` وجود داشت مقدار برگشتی در این متغیرها `true` خواهد بود و در غیر این صورت مقدار برگشتی `false`.
-
-{{< playground url=55Ga1f_c8Fz >}}
+در حالت اول کلید 'num' وجود نداشت و مقدار 0 چاپ شد. در حالت دوم مقدار 0 به کلید 'num' نسبت داده شده و همان مقدار 0 چاپ شد. حال ممکن است موقعیتی پیش بیاید که لازم باشد بدانیم که آیا یک کلید وجود دارد یا نه. در این صورت به جای یک متغیر، از دو متغیر برای جستوجو در مپ استفاده می‌کنیم:
+```go
+package main  
+  
+import "fmt"  
+  
+func main() {  
+    x := make(map[string]int)  
+    a, ok := x["num"]  
+    fmt.Println(a, ok) // 0 false  
+  
+    x["num"] = 0  
+    b, ok := x["num"]  
+    fmt.Println(b, ok) // 0 true  
+}
+```
 
 ## 1.10.8 مپ، یک جدول، یک منبع
 


### PR DESCRIPTION
گفته شده: 'مقدار کلید در یک مپ، باید یکتا باشد'. این جمله درست نیست و در صورت یکتا نبودن مقدار قبلی بازنویسی میشه. 

برای توضیح two-value assignment مثال بهتری ارائه شد.