### PR TITLE
Fix: the condition of checking whether the number is even

### DIFF
--- a/content/chapter 2/2.6-error-handling.md
+++ b/content/chapter 2/2.6-error-handling.md
@@ -231,7 +231,7 @@ func checkPositive(num int) error {
 }
 
 func checkEven(num int) error {
-	if num%2 != 1 {
+	if num%2 != 0 {
 		return notEven{num: num}
 	}
 	return nil


### PR DESCRIPTION
It is an odd number when the unequal remainder is zero