### PR TITLE
Refactor sync.Cond example

### DIFF
--- a/content/chapter 3/3.3-sync.md
+++ b/content/chapter 3/3.3-sync.md
@@ -444,48 +444,42 @@ import (
 	"sync"
 )
 
-var sharedRsc = make(map[string]interface{})
+var sharedResource = make(map[string]interface{})
 
 func main() {
 	var wg sync.WaitGroup
 	wg.Add(2)
-	m := sync.Mutex{}
-	c := sync.NewCond(&m)
-	go func() {
-		// this go routine wait for changes to the sharedRsc
-		c.L.Lock()
-		for len(sharedRsc) == 0 {
-			c.Wait()
-		}
-		fmt.Println("goroutine1", sharedRsc["rsc1"])
-		c.L.Unlock()
-		wg.Done()
-	}()
+	locker := sync.Mutex{}
+	condition := sync.NewCond(&locker)
 
-	go func() {
-		// this go routine wait for changes to the sharedRsc
-		c.L.Lock()
-		for len(sharedRsc) == 0 {
-			c.Wait()
-		}
-		fmt.Println("goroutine2", sharedRsc["rsc2"])
-		c.L.Unlock()
-		wg.Done()
-	}()
+	go waitForResourceUpdate(&wg, condition, "rsc1")
+	go waitForResourceUpdate(&wg, condition, "rsc2")
 
-	// this one writes changes to sharedRsc
-	c.L.Lock()
-	sharedRsc["rsc1"] = "foo"
-	sharedRsc["rsc2"] = "bar"
-	c.Broadcast()
-	c.L.Unlock()
+	// this one writes changes to sharedResource
+	condition.L.Lock()
+	sharedResource["rsc1"] = "a string"
+	sharedResource["rsc2"] = 123456
+	condition.Broadcast()
+	condition.L.Unlock()
+
 	wg.Wait()
+}
+
+// waitForResourceUpdate waits for a signal that a resource changed and prints it.
+func waitForResourceUpdate(wg *sync.WaitGroup, cond *sync.Cond, key string) {
+	defer wg.Done()
+	cond.L.Lock()
+	for len(sharedResource) == 0 {
+		cond.Wait()
+	}
+	fmt.Println("Resource", key, ":", sharedResource[key])
+	cond.L.Unlock()
 }
 ```
 
 ```shell
 $ go run main.go
-goroutine2 bar
-goroutine1 foo
+Resource rsc2 : 123456
+Resource rsc1 : a string
 ```
 


### PR DESCRIPTION
- Extract common goroutine logic into an external function `waitForResourceUpdate`.
- Rename variables for better clarity:
  - `sharedRsc` to `sharedResource`
  - `m` to `locker`
  - `c` to `condition`
- Add comments to explain the purpose and flow of the code.