### PR TITLE
Update 2.2-struct.md for fixing salary not displaying bug

### DIFF
--- a/content/chapter 2/2.2-struct.md
+++ b/content/chapter 2/2.2-struct.md
@@ -360,11 +360,11 @@ import (
 type employee struct {
     Name   string
     Age    int
-    salary int
+    Salary int
 }
 
 func main() {
-    emp := employee{Name: "Sam", Age: 31, salary: 2000}
+    emp := employee{Name: "Sam", Age: 31, Salary: 2000}
     //Marshal
     empJSON, err := json.Marshal(emp)
     if err != nil {


### PR DESCRIPTION
Salary not shown in output because it has declared as a private field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the Employee struct example to use an exported Salary field, improving consistency with JSON-focused sections and making the example clearer for readers.
  - Refined example initialization to reflect the exported field usage in code snippets.
- Style
  - Minor formatting cleanup (trailing newline) for improved readability without impacting content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->