### PR TITLE
Update 2.4-interface.md for calling correct method

### DIFF
--- a/content/chapter 2/2.4-interface.md
+++ b/content/chapter 2/2.4-interface.md
@@ -260,7 +260,7 @@ func callBreathe(a animal) {
 }
 
 func callWalk(a animal) {
-	a.breathe()
+	a.walk()
 }
 {{< /play >}}
 


### PR DESCRIPTION
callWalk function has been calling breathe method instead of calling walk method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the interface section’s example to call walk() within callWalk, aligning the code sample with the described behavior and removing a mismatch where breathe() was previously invoked.
  * Improves clarity for readers by ensuring the example exercises the intended method.
  * No changes to public APIs or runtime behavior; documentation-only correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->