### PR TITLE
Update 2.5-type-embedding.md for calling p2 object instead of p1

### DIFF
--- a/content/chapter 2/2.5-type-embedding.md
+++ b/content/chapter 2/2.5-type-embedding.md
@@ -134,7 +134,7 @@ func main() {
     p1.a.walk()
 
     p2 := pet2{name: "Oscar", animal: d}
-    fmt.Println(p1.name)
+    fmt.Println(p2.name)
     p2.breathe()
     p2.walk()
     p1.a.breathe()


### PR DESCRIPTION
p2 object name field not called. instead, p1 object name field called  twice.