### PR TITLE
Update 2.6-error-handling.md

### DIFF
--- a/content/chapter 2/2.6-error-handling.md
+++ b/content/chapter 2/2.6-error-handling.md
@@ -253,21 +253,34 @@ func Unwrap(err error) error
 منظورمان از unwrap کردن این است که، اگر خطایی را {{< tooltip text="هم پوشانی" note="wrap" >}}  کرده باشیم با استفاده unwrap می‌توانیم آن خطا را ببینیم.
 
 {{< play >}}
+package main
+
 import (
-    "errors"
-    "fmt"
+	"errors"
+	"fmt"
 )
-type errorOne struct{}
-func (e errorOne) Error() string {
-    return "Error One happened"
+
+type errorOne struct {
+	cause error
 }
+
+func (e errorOne) Error() string {
+	return "Error One happened"
+}
+
+func (e errorOne) Unwrap() error {
+	return e.cause
+}
+
 func main() {
-    e1 := errorOne{}
-    e2 := fmt.Errorf("E2: %w", e1)
-    e3 := fmt.Errorf("E3: %w", e2)
-    fmt.Println(errors.Unwrap(e3))
-    fmt.Println(errors.Unwrap(e2))
-    fmt.Println(errors.Unwrap(e1))
+	root := errors.New("root cause")
+	e1 := errorOne{cause: root}
+	e2 := fmt.Errorf("E2: %w", e1)
+	e3 := fmt.Errorf("E3: %w", e2)
+
+	fmt.Println(errors.Unwrap(e3)) // e2
+	fmt.Println(errors.Unwrap(e2)) // e1
+	fmt.Println(errors.Unwrap(e1)) // root
 }
 {{< /play >}}
 


### PR DESCRIPTION
2.6.4 => Error method not used directly and it is better to call it for better understanding of this example.

2.6.7 => Code not compiled because it has not package and there is a bug that Unwarp method is not return error message and return nil.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded error handling chapter with clearer examples for advanced error creation, showing both the error and its message in output.
  - Added a comprehensive walkthrough of error unwrapping, illustrating a multi-level chain and expected outputs.
  - Improved formatting and import presentation for better readability, with no changes to behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->