### PR TITLE
Update 3.3-sync.md

### DIFF
--- a/content/chapter 3/3.3-sync.md
+++ b/content/chapter 3/3.3-sync.md
@@ -435,9 +435,9 @@ import (
 func process(id int, wg *sync.WaitGroup, sem chan struct{}) {
 	defer wg.Done()
 	sem <- struct{}{} // گرفتن اسلات
+	defer func() { <-sem }() // آزاد کردن اسلات (ایمن‌تر)
 	fmt.Printf("Processing %d\n", id)
 	time.Sleep(time.Second)
-	<-sem // آزاد کردن اسلات
 }
 
 func main() {

--- a/content/chapter 3/3.3-sync.md
+++ b/content/chapter 3/3.3-sync.md
@@ -516,7 +516,14 @@ func main() {
 
 `Once` یکی از بهترین راه‌ها برای پیاده‌سازی **الگوی Singleton** در Go هست، چون به صورت ایمن و همزمانی (thread-safe) تضمین می‌کنه که فقط یک instance ساخته می‌شه.
 
-```go
+{{< /play >}}
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
 type singleton struct {
 	data string
 }
@@ -538,9 +545,11 @@ func main() {
 	s2 := GetInstance()
 	if s1 == s2 {
 		fmt.Println("Same instance")
+	} else {
+		fmt.Println("Not same")
 	}
 }
-```
+{{< /play >}}
 
 **مزیت:** نیازی به نوشتن قفل‌های اضافه یا متغیر flag نیست، چون `Once` همه چیز رو مدیریت می‌کنه.
 

--- a/content/chapter 3/3.3-sync.md
+++ b/content/chapter 3/3.3-sync.md
@@ -206,7 +206,7 @@ import (
 )
 
 type SafeMap struct {
-	mu   sync.RWMutex
+	mu   *sync.RWMutex
 	data map[string]string
 }
 
@@ -223,24 +223,27 @@ func (s *SafeMap) Write(key, value string) {
 }
 
 func main() {
-	smap := SafeMap{data: make(map[string]string)}
+	var mu sync.RWMutex
+
+	smap := SafeMap{mu: &mu, data: make(map[string]string)}
 
 	// نویسنده
 	go func() {
-		for i := 0; i < 5; i++ {
-			smap.Write("name", fmt.Sprintf("value-%d", i))
-			time.Sleep(500 * time.Millisecond)
+		for i := range 5 {
+			smap.Write(fmt.Sprintf("book-%d", i), fmt.Sprintf("value-%d", i))
+			fmt.Printf("Writer write %d\n", i)
+			time.Sleep(200 * time.Millisecond)
 		}
 	}()
 
 	// چند خواننده همزمان
-	for i := 0; i < 3; i++ {
-		go func(id int) {
-			for j := 0; j < 5; j++ {
-				fmt.Printf("Reader %d: %s\n", id, smap.Read("name"))
-				time.Sleep(300 * time.Millisecond)
+	for i := range 3 {
+		go func() {
+			for j := range 5 {
+				fmt.Printf("Reader %d read %s\n", i, smap.Read(fmt.Sprintf("book-%d", j)))
+				time.Sleep(500 * time.Millisecond)
 			}
-		}(i)
+		}()
 	}
 
 	time.Sleep(3 * time.Second)

--- a/content/chapter 3/3.3-sync.md
+++ b/content/chapter 3/3.3-sync.md
@@ -343,7 +343,15 @@ func worker(name string, wg *sync.WaitGroup) {
 
 فرض کنید می‌خواهیم چند فایل را به صورت موازی دانلود کنیم و منتظر بمانیم تا همه دانلودها کامل شوند:
 
-```go
+{{< play >}}
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
 func downloadFile(url string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	fmt.Println("Downloading:", url)
@@ -363,7 +371,7 @@ func main() {
 	wg.Wait()
 	fmt.Println("All downloads complete!")
 }
-```
+{{< play >}}
 
 ### 3.3.3.4 نکات و ترفندهای استفاده از WaitGroup
 

--- a/content/chapter 3/3.3-sync.md
+++ b/content/chapter 3/3.3-sync.md
@@ -371,7 +371,7 @@ func main() {
 	wg.Wait()
 	fmt.Println("All downloads complete!")
 }
-{{< play >}}
+{{< /play >}}
 
 ### 3.3.3.4 نکات و ترفندهای استفاده از WaitGroup
 

--- a/content/chapter 3/3.3-sync.md
+++ b/content/chapter 3/3.3-sync.md
@@ -452,7 +452,7 @@ func main() {
 	wg.Wait()
 	fmt.Println("All processing complete!")
 }
-{{< play >}}
+{{< /play >}}
 
 
 {{< hint info >}}
@@ -516,7 +516,7 @@ func main() {
 
 `Once` یکی از بهترین راه‌ها برای پیاده‌سازی **الگوی Singleton** در Go هست، چون به صورت ایمن و همزمانی (thread-safe) تضمین می‌کنه که فقط یک instance ساخته می‌شه.
 
-{{< /play >}}
+{{< play >}}
 package main
 
 import (

--- a/content/chapter 3/3.3-sync.md
+++ b/content/chapter 3/3.3-sync.md
@@ -206,7 +206,7 @@ import (
 )
 
 type SafeMap struct {
-	mu   *sync.RWMutex
+	mu   sync.RWMutex
 	data map[string]string
 }
 
@@ -223,9 +223,7 @@ func (s *SafeMap) Write(key, value string) {
 }
 
 func main() {
-	var mu sync.RWMutex
-
-	smap := SafeMap{mu: &mu, data: make(map[string]string)}
+	smap := SafeMap{data: make(map[string]string)}
 
 	// نویسنده
 	go func() {
@@ -237,13 +235,13 @@ func main() {
 	}()
 
 	// چند خواننده همزمان
-	for i := range 3 {
-		go func() {
-			for j := range 5 {
-				fmt.Printf("Reader %d read %s\n", i, smap.Read(fmt.Sprintf("book-%d", j)))
+	for i := 0; i < 3; i++ {
+		go func(id int) {
+			for j := 0; j < 5; j++ {
+				fmt.Printf("Reader %d read %s\n", id, smap.Read(fmt.Sprintf("book-%d", j)))
 				time.Sleep(500 * time.Millisecond)
 			}
-		}()
+		}(i)
 	}
 
 	time.Sleep(3 * time.Second)

--- a/content/chapter 3/3.3-sync.md
+++ b/content/chapter 3/3.3-sync.md
@@ -227,9 +227,9 @@ func main() {
 
 	// نویسنده
 	go func() {
-		for i := range 5 {
+		for i := 0; i < 5; i++ {
 			smap.Write(fmt.Sprintf("book-%d", i), fmt.Sprintf("value-%d", i))
-			fmt.Printf("Writer write %d\n", i)
+			fmt.Printf("Writer wrote %d\n", i)
 			time.Sleep(200 * time.Millisecond)
 		}
 	}()
@@ -442,7 +442,7 @@ func main() {
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 3) // حداکثر 3 goroutine همزمان
 
-	for i := range 10 {
+	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go process(i, &wg, sem)
 	}

--- a/content/chapter 3/3.3-sync.md
+++ b/content/chapter 3/3.3-sync.md
@@ -423,20 +423,28 @@ for _, task := range tasks {
 اگر درخصوص پترن Semaphore بیشتر میخواید بدانید به [اینجا](../../chapter-9/concurrency-patterns/go-concurrency-pattern-semaphore) مراجعه کنید.
 {{< /hint >}}
 
-```go
+{{< play >}}
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
 func process(id int, wg *sync.WaitGroup, sem chan struct{}) {
 	defer wg.Done()
-	sem <- struct{}{}         // گرفتن اسلات
+	sem <- struct{}{} // گرفتن اسلات
 	fmt.Printf("Processing %d\n", id)
 	time.Sleep(time.Second)
-	<-sem                      // آزاد کردن اسلات
+	<-sem // آزاد کردن اسلات
 }
 
 func main() {
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 3) // حداکثر 3 goroutine همزمان
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go process(i, &wg, sem)
 	}
@@ -444,7 +452,7 @@ func main() {
 	wg.Wait()
 	fmt.Println("All processing complete!")
 }
-```
+{{< play >}}
 
 
 {{< hint info >}}


### PR DESCRIPTION
3.3.2.3 => Code has incomprehensible output which is not showing writer execution and
               mu field in SafeMap struct changed to reference type for more more confidence,
               also the loops were optimized and the writer time were decreased and the readers
               time were increased because each reader read 5 time and it is better that writer
               write them sooner so the readers read empty keys less 

3.3.3.3 => Make the code executable

3.3.3.6 => Make the code executable

3.3.4.4 => Make the code executable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated concurrency examples: RWMutex demo uses dynamic keys, clearer writer/reader pacing and log messages; semaphore/WaitGroup demo now releases safely with defer; singleton example adds an explicit "not same" check and clearer output.
  * Converted several samples to interactive play blocks for easier experimentation.

* **Style**
  * Improved formatting, whitespace, comments, and consistency across examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->