### PR TITLE
Modify code format of last example in 3.6.7

### DIFF
--- a/content/chapter 3/3.6-channel.md
+++ b/content/chapter 3/3.6-channel.md
@@ -468,18 +468,19 @@ func main() {
 
 {{< play >}}
 package main
-import (
-    "fmt"
-)
-func main() {
-    ch := make(chan int, 1)
-    ch <- 2
-    val, ok := <-ch
-    fmt.Printf("Val: %d OK: %t\n", val, ok)
 
-    close(ch)
-    val, ok = <-ch
-    fmt.Printf("Val: %d OK: %t\n", val, ok)
+import (
+	"fmt"
+)
+
+func main() {
+	ch := make(chan int, 1)
+	ch <- 2
+	val, ok := <-ch
+	fmt.Printf("Val: %d OK: %t\n", val, ok)
+	close(ch)
+	val, ok = <-ch
+	fmt.Printf("Val: %d OK: %t\n", val, ok)
 }
 {{< /play >}}
 


### PR DESCRIPTION
Apply some indents, tabs and enters for better code format on last example in 3.6.7 section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting in Chapter 3, Section 3.6 (channels) code example: added a blank line after the package declaration and standardized import indentation. Example behavior is unchanged (buffered channel send/receive, print, close, second receive). Enhances readability and consistency across docs. No impact on app behavior or user workflows. No API or public interface changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->