### PR TITLE
Modify context name in code and the text after code

### DIFF
--- a/content/chapter 3/3.6-channel.md
+++ b/content/chapter 3/3.6-channel.md
@@ -468,18 +468,19 @@ func main() {
 
 {{< play >}}
 package main
-import (
-    "fmt"
-)
-func main() {
-    ch := make(chan int, 1)
-    ch <- 2
-    val, ok := <-ch
-    fmt.Printf("Val: %d OK: %t\n", val, ok)
 
-    close(ch)
-    val, ok = <-ch
-    fmt.Printf("Val: %d OK: %t\n", val, ok)
+import (
+	"fmt"
+)
+
+func main() {
+	ch := make(chan int, 1)
+	ch <- 2
+	val, ok := <-ch
+	fmt.Printf("Val: %d OK: %t\n", val, ok)
+	close(ch)
+	val, ok = <-ch
+	fmt.Printf("Val: %d OK: %t\n", val, ok)
 }
 {{< /play >}}
 

--- a/content/chapter 3/3.8-context.md
+++ b/content/chapter 3/3.8-context.md
@@ -292,37 +292,37 @@ func WithTimeout(parent Context, timeout time.Duration) (Context, CancelFunc)
 package main
 
 import (
-    "context"
-    "fmt"
-    "time"
+	"context"
+	"fmt"
+	"time"
 )
 
 func main() {
-    ctx := context.Background()
-    cancelCtx, cancel := context.WithTimeout(ctx, time.Second*3)
-    defer cancel()
-    go task1(cancelCtx)
-    time.Sleep(time.Second * 4)
+	ctx := context.Background()
+	withTimeoutCtx, cancel := context.WithTimeout(ctx, time.Second*3)
+	defer cancel()
+	go task1(withTimeoutCtx)
+	time.Sleep(time.Second * 4)
 }
 
 func task1(ctx context.Context) {
-    i := 1
-    for {
-        select {
-        case <-ctx.Done():
-            fmt.Println("Gracefully exit")
-            fmt.Println(ctx.Err())
-            return
-        default:
-            fmt.Println(i)
-            time.Sleep(time.Second * 1)
-            i++
-        }
-    }
+	i := 1
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("Gracefully exit")
+			fmt.Println(ctx.Err())
+			return
+		default:
+			fmt.Println(i)
+			time.Sleep(time.Second * 1)
+			i++
+		}
+	}
 }
 {{< /play >}}
 
-در کد فوق ما یک context فرزند با استفاده از تابع WithTimeout ایجاد کردیم و مدت زمان ۳ ثانیه به این تابع پاس دادیم و پس از آن context فرزند به همراه تابع cancelFunc دریافت کردیم. حالا تابع cancel را داخل defer قرار دادیم و cancelCtx را به تابع task1 که داخل گوروتین است پاس داده ایم سپس و یک Sleep به مدت ۴ ثانیه گذاشتیم تا، تابع main کارش تمام نشود. حال پس از اینکه ۳ ثانیه گذشت داخل select سیگنال cancel را دریافت کردیم و خطای context deadline exceeded که نشان دهنده اتمام شدن مدت زمان هست را چاپ کرده ایم. همانطور که متوجه شدید درخواست کلی ما لغو شده.
+در کد فوق ما یک context فرزند با استفاده از تابع WithTimeout ایجاد کردیم و مدت زمان ۳ ثانیه به این تابع پاس دادیم و پس از آن context فرزند به همراه تابع cancel دریافت کردیم. حالا تابع cancel را داخل defer قرار دادیم و withTimeoutCtx را به تابع task1 که داخل گوروتین است پاس داده ایم سپس و یک Sleep به مدت ۴ ثانیه گذاشتیم تا، تابع main کارش تمام نشود. حال پس از اینکه ۳ ثانیه گذشت داخل select سیگنال cancel را دریافت کردیم و خطای context deadline exceeded که نشان دهنده اتمام شدن مدت زمان هست را چاپ کرده ایم. همانطور که متوجه شدید درخواست کلی ما لغو شده.
 
 ## 3.8.7 تابع context.WithDeadline
 


### PR DESCRIPTION
The context name in 3.8.6 example was cancelCtx like previous example (3.8.5) and it is better to change it to withTimeoutCtx because WithTimeout context used in this example not WithCancel context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified context example in Chapter 3.8 by renaming the derived context variable for readability.
  * Updated accompanying narrative (including Persian translation) to match the new naming; no behavioral changes.

* **Style**
  * Reformatted code examples in Chapters 3.6 and 3.8 for consistency (indentation, import formatting, spacing).
  * Improved readability of examples without altering logic or outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->