### PR TITLE
Fix undefined Person struct error on 4.10.2.1 example

### DIFF
--- a/content/chapter 4/4.10-yaml.md
+++ b/content/chapter 4/4.10-yaml.md
@@ -39,6 +39,12 @@ import (
 	"log"
 )
 
+type Person struct {
+	Name 	  string
+	Age  	  int
+	IsStudent bool
+}
+
 func main() {
 	person := Person{
 		Name:      "John",


### PR DESCRIPTION
Person struct didn't decleread but it used and caused for an error on 4.10.2.1 example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded YAML marshaling example with a minimal data structure defined upfront, allowing creation of a sample value prior to marshaling.
  * Improves clarity and makes the snippet copy-paste runnable without additional context.
  * No changes to app behavior; this is documentation-only.
  * Helpful for beginners learning YAML serialization with a clear, self-contained code sample.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->