### PR TITLE
Update 4.11-csv.md

### DIFF
--- a/content/chapter 4/4.11-csv.md
+++ b/content/chapter 4/4.11-csv.md
@@ -187,7 +187,6 @@ func main() {
     f, err := os.Open("users.csv")
 
     if err != nil {
-
         log.Fatal(err)
     }
 

--- a/content/chapter 4/4.11-csv.md
+++ b/content/chapter 4/4.11-csv.md
@@ -238,12 +238,12 @@ func main() {
     }
 
     f, err := os.Create("users.csv")
-    defer f.Close()
 
     if err != nil {
-
-        log.Fatalln("failed to open file", err)
+        log.Fatalln("failed to create file", err)
     }
+
+	defer f.Close()
 
     w := csv.NewWriter(f)
     defer w.Flush()

--- a/content/chapter 4/4.11-csv.md
+++ b/content/chapter 4/4.11-csv.md
@@ -264,40 +264,39 @@ func main() {
 تابع WriteAll چندین رکورد CSV را با استفاده از Write برای writer می‌نویسد و سپس Flush را فراخوانی می‌کند.
 
 {{< play >}}
-
 //write_all.go//
 
 package main
 
 import (
-    "encoding/csv"
-    "log"
-    "os"
+	"encoding/csv"
+	"log"
+	"os"
 )
 
 func main() {
 
-    records := [][]string{
-        {"first_name", "last_name", "occupation"},
-        {"John", "Doe", "gardener"},
-        {"Lucy", "Smith", "teacher"},
-        {"Brian", "Bethamy", "programmer"},
-    }
+	records := [][]string{
+		{"first_name", "last_name", "occupation"},
+		{"John", "Doe", "gardener"},
+		{"Lucy", "Smith", "teacher"},
+		{"Brian", "Bethamy", "programmer"},
+	}
 
-    f, err := os.Create("users.csv")
-    defer f.Close()
+	f, err := os.Create("users.csv")
 
-    if err != nil {
+	if err != nil {
+		log.Fatalln("failed to create file", err)
+	}
 
-        log.Fatalln("failed to open file", err)
-    }
+	defer f.Close()
 
-    w := csv.NewWriter(f)
-    err = w.WriteAll(records) // calls Flush internally
+	w := csv.NewWriter(f)
+	err = w.WriteAll(records) // calls Flush internally
 
-    if err != nil {
-        log.Fatal(err)
-    }
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 {{< /play >}}
 


### PR DESCRIPTION
4.11.4 => Remove additional enter in error handling

4.11.5 => Fix warning that defer f.Close() should be after error handling, remove additional enter in error handling and modify log.Fatalln message

4.11.6 => Fix warning that defer f.Close() should be after error handling, remove additional enter in error handling and modify log.Fatalln message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected CSV writing examples to handle file creation/closure properly, improving reliability.
  * Clarified error messages to accurately describe creation failures.
  * Aligned WriteAll example with the updated approach; CSV read/write semantics unchanged.

* **Style**
  * Standardized indentation and cleaned up whitespace in code samples for consistency and readability across sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->