### PR TITLE
Fix cfg.SaveTo() error and add some indent to 4.12 example

### DIFF
--- a/content/chapter 4/4.12-ini.md
+++ b/content/chapter 4/4.12-ini.md
@@ -44,39 +44,47 @@ enforce_domain = true
 
 {{< play >}}
 package main
+
 import (
-"fmt"
-"os"
-"gopkg.in/ini.v1"
+	"fmt"
+	"gopkg.in/ini.v1"
+	"os"
 )
 
 func main() {
-cfg, err := ini.Load("my.ini")
+	cfg, err := ini.Load("my.ini")
 
-if err != nil {
-fmt.Printf("Fail to read file: %v", err)
-os.Exit(1)
-}
+	if err != nil {
+		fmt.Printf("Fail to read file: %v", err)
+		os.Exit(1)
+	}
 
-// Classic read of values, default section can be represented as empty string
-fmt.Println("App Mode:", cfg.Section("").Key("app_mode").String())
-fmt.Println("Data Path:", cfg.Section("paths").Key("data").String())
+	// Classic read of values, default section can be represented as empty string
+	fmt.Println("App Mode:",
+	cfg.Section("").Key("app_mode").String())
 
-// Let's do some candidate value limitation
-fmt.Println("Server Protocol:",
-cfg.Section("server").Key("protocol").In("http", []string{"http", "https"}))
+	fmt.Println("Data Path:",
+	cfg.Section("paths").Key("data").String())
 
-// Value read that is not in candidates will be discarded and fall back to given default value
-fmt.Println("Email Protocol:", cfg.Section("server").Key("protocol").In("smtp", []string{"imap", "smtp"}))
+	// Let's do some candidate value limitation
+	fmt.Println("Server Protocol:",
+	cfg.Section("server").Key("protocol").In("http", []string{"http", "https"}))
 
-// Try out auto-type conversion
-fmt.Printf("Port Number: (%[1]T) %[1]d\n", cfg.Section("server").Key("http_port").MustInt(9999))
+	// Value read that is not in candidates will be discarded and fall back to given default value
+	fmt.Println("Email Protocol:",
+	cfg.Section("server").Key("protocol").In("smtp", []string{"imap", "smtp"}))
 
-fmt.Printf("Enforce Domain: (%[1]T) %[1]v\n", cfg.Section("server").Key("enforce_domain").MustBool(false))
+	// Try out auto-type conversion
+	fmt.Printf("Port Number: (%[1]T) %[1]d\n",
+	cfg.Section("server").Key("http_port").MustInt(9999))
 
-// Now, make some changes and save it
-cfg.Section("").Key("app_mode").SetValue("production") cfg.SaveTo("my.ini.local")
+	fmt.Printf("Enforce Domain: (%[1]T) %[1]v\n",
+	cfg.Section("server").Key("enforce_domain").MustBool(false))
 
+	// Now, make some changes and save it
+	cfg.Section("").Key("app_mode").SetValue("production")
+
+	cfg.SaveTo("my.ini.local")
 }
 {{< /play >}}
 


### PR DESCRIPTION
Fix error that cfg.SaveTo() should be in the seprate line and add some indent to the 4.12 example.