### PR TITLE
Print other enums for better understanding

### DIFF
--- a/content/chapter 4/4.17-stringer.md
+++ b/content/chapter 4/4.17-stringer.md
@@ -42,6 +42,8 @@ func (a Age) String() string {
 
 func main() {
 	fmt.Println(CHILDERN.String())
+	fmt.Println(ADOLESCENTS.String())
+	fmt.Println(ADULTS.String())
 }
 {{< /play >}}
 


### PR DESCRIPTION
Print other enums for better understanding on 4.17.1 example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Expanded the example to print string representations for three age groups instead of just one, improving clarity and demonstrating multiple outputs.
  - Updated sample output to reflect the additional print statements, helping readers understand expected behavior across different cases.
  - No changes to the underlying method or API; only example usage and displayed output were adjusted for better illustration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->